### PR TITLE
fix: add css reset

### DIFF
--- a/packages/widget/src/components/address-input/address-input.ts
+++ b/packages/widget/src/components/address-input/address-input.ts
@@ -1,14 +1,15 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import type { HTMLTemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { Network } from '@buildwithsygma/sygma-sdk-core';
 import { when } from 'lit/directives/when.js';
 import { validateAddress } from '../../utils';
+import { Component } from '../base-component/base-component';
 import { styles } from './styles';
 
 @customElement('sygma-address-input')
-export class AddressInput extends LitElement {
+export class AddressInput extends Component {
   static styles = styles;
   @property({
     type: String

--- a/packages/widget/src/components/address-input/address-input.ts
+++ b/packages/widget/src/components/address-input/address-input.ts
@@ -5,11 +5,11 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { Network } from '@buildwithsygma/sygma-sdk-core';
 import { when } from 'lit/directives/when.js';
 import { validateAddress } from '../../utils';
-import { Component } from '../base-component/base-component';
+import { BaseComponent } from '../base-component/base-component';
 import { styles } from './styles';
 
 @customElement('sygma-address-input')
-export class AddressInput extends Component {
+export class AddressInput extends BaseComponent {
   static styles = styles;
   @property({
     type: String

--- a/packages/widget/src/components/amount-selector/amount-selector.ts
+++ b/packages/widget/src/components/amount-selector/amount-selector.ts
@@ -5,11 +5,11 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
-import { Component } from '../base-component/base-component';
+import { BaseComponent } from '../base-component/base-component';
 import { styles } from './styles';
 
 @customElement('sygma-resource-selector')
-export class AmountSelector extends Component {
+export class AmountSelector extends BaseComponent {
   static styles = styles;
   @property({
     type: Array,

--- a/packages/widget/src/components/amount-selector/amount-selector.ts
+++ b/packages/widget/src/components/amount-selector/amount-selector.ts
@@ -1,14 +1,15 @@
 import type { Resource } from '@buildwithsygma/sygma-sdk-core';
 import type { HTMLTemplateResult } from 'lit';
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
+import { Component } from '../base-component/base-component';
 import { styles } from './styles';
 
 @customElement('sygma-resource-selector')
-export class AmountSelector extends LitElement {
+export class AmountSelector extends Component {
   static styles = styles;
   @property({
     type: Array,

--- a/packages/widget/src/components/base-component/base-component.ts
+++ b/packages/widget/src/components/base-component/base-component.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup } from 'lit';
 import { LitElement } from 'lit';
 import { resetCSS } from './reset';
 
-export abstract class Component extends LitElement {
+export abstract class BaseComponent extends LitElement {
   private static _styles: CSSResultGroup;
 
   static get styles(): CSSResultGroup {

--- a/packages/widget/src/components/base-component/base-component.ts
+++ b/packages/widget/src/components/base-component/base-component.ts
@@ -1,0 +1,20 @@
+import type { CSSResultGroup } from 'lit';
+import { LitElement } from 'lit';
+import { resetCSS } from './reset';
+
+export abstract class Component extends LitElement {
+  private static _styles: CSSResultGroup;
+
+  static get styles(): CSSResultGroup {
+    const derivedStyles = this._styles || [];
+
+    return [
+      resetCSS,
+      ...(Array.isArray(derivedStyles) ? derivedStyles : [derivedStyles])
+    ];
+  }
+
+  static set styles(styles: CSSResultGroup) {
+    this._styles = styles;
+  }
+}

--- a/packages/widget/src/components/base-component/reset.ts
+++ b/packages/widget/src/components/base-component/reset.ts
@@ -1,0 +1,389 @@
+import { css } from 'lit';
+
+export const resetCSS = css`
+  /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+  /* Document
+     ========================================================================== */
+
+  /**
+   * 1. Correct the line height in all browsers.
+   * 2. Prevent adjustments of font size after orientation changes in iOS.
+   */
+
+  html {
+    line-height: 1.15; /* 1 */
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
+
+  /* Sections
+     ========================================================================== */
+
+  /**
+   * Remove the margin in all browsers.
+   */
+
+  body {
+    margin: 0;
+  }
+
+  /**
+   * Render the \`main\` element consistently in IE.
+   */
+
+  main {
+    display: block;
+  }
+
+  /**
+   * Correct the font size and margin on \`h1\` elements within \`section\` and
+   * \`article\` contexts in Chrome, Firefox, and Safari.
+   */
+
+  h1 {
+    margin: 0.67em 0;
+
+    font-size: 2em;
+  }
+
+  /* Grouping content
+     ========================================================================== */
+
+  /**
+   * 1. Add the correct box sizing in Firefox.
+   * 2. Show the overflow in Edge and IE.
+   */
+
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
+
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd \`em\` font sizing in all browsers.
+   */
+
+  pre {
+    font-size: 1em; /* 2 */
+    // stylelint-disable-next-line font-family-no-duplicate-names
+    font-family: monospace, monospace; /* 1 */
+  }
+
+  /* Text-level semantics
+     ========================================================================== */
+
+  /**
+   * Remove the gray background on active links in IE 10.
+   */
+
+  a {
+    background-color: transparent;
+  }
+
+  /**
+   * 1. Remove the bottom border in Chrome 57-
+   * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+   */
+
+  abbr[title] {
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+
+    border-bottom: none; /* 1 */
+  }
+
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd \`em\` font sizing in all browsers.
+   */
+
+  code,
+  kbd,
+  samp {
+    font-size: 1em; /* 2 */
+    // stylelint-disable-next-line font-family-no-duplicate-names
+    font-family: monospace, monospace; /* 1 */
+  }
+
+  /**
+   * Add the correct font size in all browsers.
+   */
+
+  small {
+    font-size: 80%;
+  }
+
+  /**
+   * Prevent \`sub\` and \`sup\` elements from affecting the line height in
+   * all browsers.
+   */
+
+  sub,
+  sup {
+    position: relative;
+
+    font-size: 75%;
+    line-height: 0;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  /* Embedded content
+     ========================================================================== */
+
+  /**
+   * Remove the border on images inside links in IE 10.
+   */
+
+  img {
+    border-style: none;
+  }
+
+  /* Forms
+     ========================================================================== */
+
+  /**
+   * 1. Change the font styles in all browsers.
+   * 2. Remove the margin in Firefox and Safari.
+   */
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    margin: 0; /* 2 */
+
+    font-size: 100%; /* 1 */
+    font-family: inherit; /* 1 */
+    line-height: 1.15; /* 1 */
+  }
+
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+
+  button,
+  input {
+    /* 1 */
+    overflow: visible;
+  }
+
+  /**
+   * Remove arrows on number input
+   * 1. Chrome, Safari, Edge, Opera
+   * 2. Firefox
+   */
+
+  /* 1 */
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    margin: 0;
+
+    appearance: none;
+  }
+
+  /* 2 */
+
+  input[type='number'] {
+    appearance: textfield;
+  }
+
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+
+  button,
+  select {
+    /* 1 */
+    text-transform: none;
+  }
+
+  /**
+   * Correct the inability to style clickable types in iOS and Safari.
+   */
+
+  button,
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-appearance: button;
+  }
+
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+
+  button::-moz-focus-inner,
+  [type='button']::-moz-focus-inner,
+  [type='reset']::-moz-focus-inner,
+  [type='submit']::-moz-focus-inner {
+    padding: 0;
+
+    border-style: none;
+  }
+
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+
+  button:-moz-focusring,
+  [type='button']:-moz-focusring,
+  [type='reset']:-moz-focusring,
+  [type='submit']:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  /**
+   * Correct the padding in Firefox.
+   */
+
+  fieldset {
+    padding: 0.35em 0.75em 0.625em;
+  }
+
+  /**
+   * 1. Correct the text wrapping in Edge and IE.
+   * 2. Correct the color inheritance from \`fieldset\` elements in IE.
+   * 3. Remove the padding so developers are not caught out when they zero out
+   *    \`fieldset\` elements in all browsers.
+   */
+
+  legend {
+    display: table; /* 1 */
+    box-sizing: border-box; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+
+    color: inherit; /* 2 */
+    white-space: normal; /* 1 */
+  }
+
+  /**
+   * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+   */
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  /**
+   * Remove the default vertical scrollbar in IE 10+.
+   */
+
+  textarea {
+    overflow: auto;
+  }
+
+  /**
+   * 1. Add the correct box sizing in IE 10.
+   * 2. Remove the padding in IE 10.
+   */
+
+  [type='checkbox'],
+  [type='radio'] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+
+  [type='number']::-webkit-inner-spin-button,
+  [type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+
+  [type='search'] {
+    outline-offset: -2px; /* 2 */
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-appearance: textfield; /* 1 */
+  }
+
+  /**
+   * Remove the inner padding in Chrome and Safari on macOS.
+   */
+
+  [type='search']::-webkit-search-decoration {
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-appearance: none;
+  }
+
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to \`inherit\` in Safari.
+   */
+
+  ::-webkit-file-upload-button {
+    font: inherit; /* 2 */
+    // stylelint-disable-next-line property-no-vendor-prefix
+    -webkit-appearance: button; /* 1 */
+  }
+
+  /* Interactive
+     ========================================================================== */
+
+  /*
+   * Add the correct display in Edge, IE 10+, and Firefox.
+   */
+
+  details {
+    display: block;
+  }
+
+  /*
+   * Add the correct display in all browsers.
+   */
+
+  summary {
+    display: list-item;
+  }
+
+  /* Misc
+     ========================================================================== */
+
+  /**
+   * Add the correct display in IE 10+.
+   */
+
+  template {
+    display: none;
+  }
+
+  /**
+   * Add the correct display in IE 10.
+   */
+
+  [hidden] {
+    display: none;
+  }
+`;

--- a/packages/widget/src/components/network-selector/network-selector.ts
+++ b/packages/widget/src/components/network-selector/network-selector.ts
@@ -1,11 +1,12 @@
 import type { Domain } from '@buildwithsygma/sygma-sdk-core';
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import type { HTMLTemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
 import { capitalize } from '../../utils';
 import { networkIconsMap, chevronIcon } from '../../assets';
+import { Component } from '../base-component/base-component';
 import { styles } from './styles';
 
 export const Directions = {
@@ -16,7 +17,7 @@ export const Directions = {
 type Direction = (typeof Directions)[keyof typeof Directions];
 
 @customElement('sygma-network-selector')
-export class NetworkSelector extends LitElement {
+export class NetworkSelector extends Component {
   static styles = styles;
 
   @state()

--- a/packages/widget/src/components/network-selector/network-selector.ts
+++ b/packages/widget/src/components/network-selector/network-selector.ts
@@ -6,7 +6,7 @@ import { map } from 'lit/directives/map.js';
 import { when } from 'lit/directives/when.js';
 import { capitalize } from '../../utils';
 import { networkIconsMap, chevronIcon } from '../../assets';
-import { Component } from '../base-component/base-component';
+import { BaseComponent } from '../base-component/base-component';
 import { styles } from './styles';
 
 export const Directions = {
@@ -17,7 +17,7 @@ export const Directions = {
 type Direction = (typeof Directions)[keyof typeof Directions];
 
 @customElement('sygma-network-selector')
-export class NetworkSelector extends Component {
+export class NetworkSelector extends BaseComponent {
   static styles = styles;
 
   @state()

--- a/packages/widget/src/widget.ts
+++ b/packages/widget/src/widget.ts
@@ -8,10 +8,10 @@ import './components/network-selector';
 import './components/amount-selector';
 import './components/address-input';
 import { Directions } from './components/network-selector/network-selector';
-import { Component } from './components/base-component/base-component';
+import { BaseComponent } from './components/base-component/base-component';
 
 @customElement('sygmaprotocol-widget')
-class SygmaProtocolWidget extends Component {
+class SygmaProtocolWidget extends BaseComponent {
   static styles = styles;
 
   private widgetController = new WidgetController(this, {});

--- a/packages/widget/src/widget.ts
+++ b/packages/widget/src/widget.ts
@@ -1,5 +1,5 @@
 import type { HTMLTemplateResult } from 'lit';
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { styles } from './styles';
 import { switchNetworkIcon, sygmaLogo } from './assets';
@@ -8,9 +8,10 @@ import './components/network-selector';
 import './components/amount-selector';
 import './components/address-input';
 import { Directions } from './components/network-selector/network-selector';
+import { Component } from './components/base-component/base-component';
 
 @customElement('sygmaprotocol-widget')
-class SygmaProtocolWidget extends LitElement {
+class SygmaProtocolWidget extends Component {
   static styles = styles;
 
   private widgetController = new WidgetController(this, {});


### PR DESCRIPTION
Adds a style reseet/normalize. From now on all components should extend `BaseComponent` instead of `LitElement`

## Description

<!--- Describe your changes in detail -->

## Related Issue Or Context

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change here -->

Closes: #<issue>

## How Has This Been Tested? Testing details.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in sygma-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
