### PR TITLE
fix: Switching to a different TOKEN mapping for "From - TO" relationship is not updated in UI if amount is inserted

### DIFF
--- a/.github/workflows/cf-deploy-react.yml
+++ b/.github/workflows/cf-deploy-react.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-    paths:
-    - 'packages/react/**'
+      - dev
   pull_request:
     branches:
       - main
-    paths:
-      - 'packages/react/**'
+      - dev
 
 jobs:
   deploy:
@@ -37,5 +35,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: sygma-react-widget
           directory: ./examples/react-widget-app/dist
-          branch: main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cf-deploy-widget.yml
+++ b/.github/workflows/cf-deploy-widget.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-    paths:
-    - 'packages/widget/**'
+      - dev
   pull_request:
     branches:
       - main
-    paths:
-      - 'packages/widget/**'
+      - dev
 
 jobs:
   deploy:
@@ -37,5 +35,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: sygma-widget
           directory: ./packages/widget/dist
-          branch: main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: "ci / test"
 on:
   push:
     branches:
-      - main # runs on push to master, add more branches if you use them
+      - main
+      - dev
   pull_request:
     branches:
       - '**' # runs on update to pull request on any branch

--- a/packages/widget/src/assets/icons/identicon.ts
+++ b/packages/widget/src/assets/icons/identicon.ts
@@ -1,0 +1,157 @@
+import { html } from 'lit';
+
+const identicon = html`
+  <svg
+    part="identicon"
+    width="49"
+    height="50"
+    viewBox="0 0 49 50"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="24.3483"
+      cy="24.3483"
+      r="23.9285"
+      transform="matrix(-1 0 0 1 48.9502 0.469238)"
+      fill="white"
+      stroke="#CBCBCB"
+      stroke-width="0.839598"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 28.0591 5.50659)"
+      fill="#95A6FF"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 35.043 9.61597)"
+      fill="#3B0D75"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 42.2329 13.7244)"
+      fill="#00FFE0"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 13.8838 13.7244)"
+      fill="#3F8AC0"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 21.0737 9.61597)"
+      fill="#D900EC"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 28.0591 13.5188)"
+      fill="#3F8AC0"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 35.043 17.6274)"
+      fill="#FF1593"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 42.2329 21.7358)"
+      fill="#95A6FF"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 13.8838 21.7358)"
+      fill="#95A6FF"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 21.0737 17.6274)"
+      fill="#3B0D75"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 28.0591 21.5303)"
+      fill="#00FFE0"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 35.043 25.6396)"
+      fill="#D900EC"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 42.2329 29.748)"
+      fill="#3B0D75"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 13.8838 29.748)"
+      fill="#3B0D75"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 21.0737 25.6396)"
+      fill="#FF1593"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 28.0591 29.543)"
+      fill="#FF1593"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 35.043 33.6511)"
+      fill="#95A6FF"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 21.0737 33.6511)"
+      fill="#95A6FF"
+    />
+    <circle
+      cx="3.28694"
+      cy="3.28694"
+      r="3.28694"
+      transform="matrix(-1 0 0 1 28.0591 37.5547)"
+      fill="#3F8AC0"
+    />
+  </svg>
+`;
+
+export default identicon;

--- a/packages/widget/src/assets/index.ts
+++ b/packages/widget/src/assets/index.ts
@@ -13,6 +13,9 @@ import phalaNetworkIcon from './icons/phalaNetworkIcon';
 import polygonNetworkIcon from './icons/polygonNetworkIcon';
 import switchNetworkIcon from './icons/switchNetwork';
 import sygmaLogo from './icons/sygmaLogo';
+import identicon from './icons/identicon';
+import plusIcon from './icons/plusIcon';
+import greenCircleIcon from './icons/greenCircleIcon';
 
 export const networkIconsMap = {
   ethereum: ethereumIcon,
@@ -37,5 +40,8 @@ export {
   noNetworkIcon,
   chevronIcon,
   greenMark,
-  loaderIcon
+  loaderIcon,
+  identicon,
+  plusIcon,
+  greenCircleIcon
 };

--- a/packages/widget/src/components/address-input/address-input.ts
+++ b/packages/widget/src/components/address-input/address-input.ts
@@ -24,7 +24,7 @@ export class AddressInput extends BaseComponent {
   @property({
     type: String
   })
-  network: Network = Network.EVM;
+  networkType: Network = Network.EVM;
 
   @state()
   errorMessage: string | null = null;
@@ -46,7 +46,7 @@ export class AddressInput extends BaseComponent {
       return;
     }
 
-    this.errorMessage = validateAddress(trimedValue, this.network);
+    this.errorMessage = validateAddress(trimedValue, this.networkType);
 
     if (!this.errorMessage) {
       void this.onAddressChange(trimedValue);

--- a/packages/widget/src/components/address-input/styles.ts
+++ b/packages/widget/src/components/address-input/styles.ts
@@ -6,6 +6,7 @@ export const styles = css`
     flex-direction: column;
     justify-content: center;
     gap: 0.5rem;
+    margin-top: 1rem;
     min-height: 7.75rem; // TOO: remove this hardcoded value
   }
 
@@ -47,5 +48,6 @@ export const styles = css`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    margin-bottom: 0.25rem;
   }
 `;

--- a/packages/widget/src/components/amount-selector/amount-selector.ts
+++ b/packages/widget/src/components/amount-selector/amount-selector.ts
@@ -8,9 +8,9 @@ import { when } from 'lit/directives/when.js';
 import { networkIconsMap } from '../../assets';
 import { TokenBalanceController } from '../../controllers/wallet-manager/token-balance';
 import { tokenBalanceToNumber } from '../../utils/token';
-import { BaseComponent } from '../common';
 import type { DropdownOption } from '../common/dropdown/dropdown';
 import { DEFAULT_ETH_DECIMALS } from '../../constants';
+import { BaseComponent } from '../common/base-component';
 import { styles } from './styles';
 
 @customElement('sygma-resource-selector')

--- a/packages/widget/src/components/amount-selector/styles.ts
+++ b/packages/widget/src/components/amount-selector/styles.ts
@@ -4,7 +4,6 @@ export const styles = css`
   .amountSelectorContainer {
     display: flex;
     padding: 0.75rem;
-    margin: 0.5rem 0;
     align-items: center;
     border-radius: 1.5rem;
     flex-direction: column;

--- a/packages/widget/src/components/common/buttons/connect-wallet.styles.ts
+++ b/packages/widget/src/components/common/buttons/connect-wallet.styles.ts
@@ -14,8 +14,7 @@ export const connectWalletStyles = css`
     align-items: center;
   }
 
-  .walletAddress,
-  .connectWalletButton {
+  .walletAddress {
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--zinc-700);
@@ -26,14 +25,25 @@ export const connectWalletStyles = css`
   }
 
   .connectWalletButton {
-    padding: 0.375rem 0.5rem;
+    display: flex;
+    align-items: center;
+    padding: 0.38rem 0.75rem;
     border-radius: 2.5rem;
-    background-color: var(--zinc-100);
-    border: 1px solid var(--gray-100);
+    background: var(--zinc-800);
+    color: var(--zinc-200);
+    font-size: 0.875rem;
+    font-weight: 500;
+    outline: none;
+    border: none;
     cursor: pointer;
-  }
+    transition: filter 0.3s ease;
 
-  .connectWalletButton:hover {
-    background-image: linear-gradient(rgb(0 0 0/3%) 0 0);
+    &:hover {
+      filter: brightness(120%);
+    }
+
+    svg {
+      margin-right: 0.5rem;
+    }
   }
 `;

--- a/packages/widget/src/components/common/buttons/connect-wallet.ts
+++ b/packages/widget/src/components/common/buttons/connect-wallet.ts
@@ -1,18 +1,20 @@
 import type { Domain } from '@buildwithsygma/sygma-sdk-core';
 import { consume } from '@lit/context';
-import type { HTMLTemplateResult, PropertyValues } from 'lit';
+import type { HTMLTemplateResult, PropertyValues, TemplateResult } from 'lit';
 import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 
-import greenCircleIcon from '../../../assets/icons/greenCircleIcon';
-import plusIcon from '../../../assets/icons/plusIcon';
+import { choose } from 'lit/directives/choose.js';
+import { greenCircleIcon, plusIcon } from '../../../assets';
 import type { WalletContext } from '../../../context';
 import { walletContext } from '../../../context';
 import { WalletController } from '../../../controllers';
 import { shortAddress } from '../../../utils';
-import { BaseComponent } from '../base-component/base-component';
+import { BaseComponent } from '../base-component';
 
+import { WalletContextKeys } from '../../../context/wallet';
 import { connectWalletStyles } from './connect-wallet.styles';
 
 @customElement('sygma-connect-wallet-btn')
@@ -28,9 +30,7 @@ export class ConnectWalletButton extends BaseComponent {
   })
   sourceNetwork?: Domain;
 
-  @property({
-    type: String
-  })
+  @property({ type: String })
   dappUrl?: string;
 
   @consume({ context: walletContext, subscribe: true })
@@ -62,49 +62,63 @@ export class ConnectWalletButton extends BaseComponent {
     return !!this.wallets.evmWallet || !!this.wallets.substrateWallet;
   }
 
-  render(): HTMLTemplateResult {
+  private renderConnectWalletButton(): HTMLTemplateResult | undefined {
+    if (this.wallets.substrateWallet) return;
+
+    return when(
+      this.isWalletConnected(),
+      () =>
+        html` <button
+          role="button"
+          @click=${this.onDisconnectClicked}
+          class="connectWalletButton"
+        >
+          Disconnect
+        </button>`,
+      () =>
+        html` <button
+          @click=${this.onConnectClicked}
+          role="button"
+          class="connectWalletButton"
+        >
+          ${plusIcon} Connect Wallet
+        </button>`
+    );
+  }
+
+  private renderWalletAddress(): TemplateResult | undefined {
     const evmWallet = this.wallets.evmWallet;
-    const substrateWallet = this.wallets.substrateWallet;
-    //TODO: this is wrong we need to enable user to select account
-    const substrateAccount = substrateWallet?.accounts[0];
-    return html` <div class="connectWalletContainer">
-      ${when(
-        !!evmWallet?.address,
-        () =>
-          html`<span class="walletAddress" title=${evmWallet?.address ?? ''}
-            >${greenCircleIcon} ${shortAddress(evmWallet?.address ?? '')}</span
-          >`
-      )}
-      ${when(
-        !!substrateAccount,
+    const activeWalletKey = (
+      Object.keys(this.wallets) as (keyof typeof this.wallets)[]
+    ).find((key) => !!this.wallets[key]);
+
+    return choose(activeWalletKey, [
+      [
+        WalletContextKeys.EVM_WALLET,
         () =>
           html`<span
             class="walletAddress"
-            title=${substrateAccount?.address ?? ''}
-            >${greenCircleIcon} ${substrateAccount?.name}
-            ${shortAddress(substrateAccount?.address ?? '')}</span
-          >`
-      )}
-      ${when(
-        this.isWalletConnected(),
-        () =>
-          html`<button
-            @click=${this.onDisconnectClicked}
-            class="connectWalletButton"
+            title=${ifDefined(evmWallet?.address)}
           >
-            Disconnect
-          </button>`,
-        () =>
-          html`<button
-            @click=${this.onConnectClicked}
-            class="connectWalletButton"
-          >
-            ${plusIcon} Connect Wallet
-          </button>`
-      )}
+            ${greenCircleIcon} ${shortAddress(evmWallet?.address ?? '')}
+          </span>`
+      ],
+      [
+        WalletContextKeys.SUBSTRATE_WALLET,
+        () => html`
+          <sygma-substrate-account-selector></sygma-substrate-account-selector>
+        `
+      ]
+    ]);
+  }
+
+  render(): HTMLTemplateResult {
+    return html` <div class="connectWalletContainer">
+      ${this.renderWalletAddress()} ${this.renderConnectWalletButton()}
     </div>`;
   }
 }
+
 declare global {
   interface HTMLElementTagNameMap {
     'sygma-connect-wallet-btn': ConnectWalletButton;

--- a/packages/widget/src/components/common/buttons/connect-wallet.ts
+++ b/packages/widget/src/components/common/buttons/connect-wallet.ts
@@ -39,7 +39,7 @@ export class ConnectWalletButton extends BaseComponent {
 
   private walletController = new WalletController(this);
 
-  updated(changedProperties: PropertyValues): void {
+  updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (changedProperties.has('sourceNetwork')) {
       this.walletController.sourceNetworkUpdated(this.sourceNetwork);

--- a/packages/widget/src/components/common/dropdown/dropdown.ts
+++ b/packages/widget/src/components/common/dropdown/dropdown.ts
@@ -56,7 +56,7 @@ export class Dropdown extends BaseComponent {
     removeEventListener('click', this._handleOutsideClick);
   }
 
-  updated(changedProperties: PropertyValues<typeof this>): void {
+  updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     //if options changed, check if we have selected option that doesn't exist
     if (changedProperties.has('options') && this.selectedOption) {

--- a/packages/widget/src/components/common/dropdown/styles.ts
+++ b/packages/widget/src/components/common/dropdown/styles.ts
@@ -3,14 +3,15 @@ import { css } from 'lit';
 export const styles = css`
   .dropdownWrapper {
     min-width: 7.5rem;
+    padding: 0.75rem 1rem;
     position: relative;
-    width: 100%;
     height: 100%;
   }
 
   .dropdown {
     outline: none;
     height: 100%;
+    width: 100%;
   }
 
   .dropdownTrigger {
@@ -45,6 +46,8 @@ export const styles = css`
     position: absolute;
     background-color: var(--white);
     width: 100%;
+    left: 0;
+    min-width: fit-content;
     border-radius: 0.75rem;
     border: 0.0625rem solid var(--gray-100);
     box-shadow:
@@ -63,6 +66,11 @@ export const styles = css`
     padding: 0.75rem 1rem;
     cursor: pointer;
     transition: background-color 0.3s ease;
+    border-bottom: 1px solid var(--zinc-200);
+
+    &:last-child {
+      border-bottom: none;
+    }
 
     svg {
       max-width: 1.43656rem;
@@ -87,9 +95,6 @@ export const styles = css`
 
   .optionName {
     margin-left: 0.5rem;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
   }
 
   .dropdownLabel {

--- a/packages/widget/src/components/common/index.ts
+++ b/packages/widget/src/components/common/index.ts
@@ -2,4 +2,3 @@ export { Button } from './buttons/button';
 export { ConnectWalletButton } from './buttons/connect-wallet';
 export { Dropdown } from './dropdown/dropdown';
 export { OverlayComponent } from './overlay-component';
-export { BaseComponent } from './base-component';

--- a/packages/widget/src/components/common/overlay-component/overlay-component.ts
+++ b/packages/widget/src/components/common/overlay-component/overlay-component.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import type { HTMLTemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { BaseComponent } from '../base-component/base-component';
+import { BaseComponent } from '../base-component';
 import { styles } from './styles';
 
 @customElement('sygma-overlay-component')

--- a/packages/widget/src/components/index.ts
+++ b/packages/widget/src/components/index.ts
@@ -2,5 +2,6 @@ export { AmountSelector } from './amount-selector';
 export { NetworkSelector } from './network-selector';
 export { OverlayComponent } from './common/overlay-component';
 export { ConnectWalletButton } from './common/buttons/connect-wallet';
+export { SubstrateAccountSelector } from './substrate-account-selector';
 export { AddressInput } from './address-input';
 export { FungibleTokenTransfer } from './transfer/fungible/fungible-token-transfer';

--- a/packages/widget/src/components/network-selector/network-selector.ts
+++ b/packages/widget/src/components/network-selector/network-selector.ts
@@ -5,7 +5,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
 
 import { networkIconsMap } from '../../assets';
-import { BaseComponent } from '../common/base-component/base-component';
+import { BaseComponent } from '../common/base-component';
 import type { DropdownOption } from '../common/dropdown/dropdown';
 
 import { styles } from './styles';

--- a/packages/widget/src/components/network-selector/styles.ts
+++ b/packages/widget/src/components/network-selector/styles.ts
@@ -7,10 +7,8 @@ export const styles = css`
     display: flex;
     max-width: 19.625rem;
     max-height: 4.625rem;
-    padding: 0.75rem 1rem;
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
-    gap: 0.25rem;
   }
 `;

--- a/packages/widget/src/components/substrate-account-selector/index.ts
+++ b/packages/widget/src/components/substrate-account-selector/index.ts
@@ -1,0 +1,1 @@
+export { SubstrateAccountSelector } from './substrate-account-selector';

--- a/packages/widget/src/components/substrate-account-selector/styles.ts
+++ b/packages/widget/src/components/substrate-account-selector/styles.ts
@@ -1,0 +1,81 @@
+import { css } from 'lit';
+
+export const substrateAccountSelectorStyles = css`
+  // Custom option for dropdown. We are using part as we pass the custom option
+  // to the dropdown component as a property
+  dropdown-component::part(dropdown) {
+    border-radius: 2.5rem;
+  }
+
+  dropdown-component::part(dropdownWrapper) {
+    padding: 0;
+  }
+
+  dropdown-component::part(customOptionContent) {
+    display: flex;
+    flex-direction: column;
+  }
+
+  dropdown-component::part(customOptionContentName) {
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  dropdown-component::part(customOptionContentMain) {
+    display: flex;
+    align-items: center;
+  }
+
+  dropdown-component::part(identicon) {
+    max-width: 3rem;
+    width: fit-content;
+  }
+
+  dropdown-component::part(customOptionContentAccountData) {
+    display: flex;
+    flex-direction: column;
+    margin-left: 0.5rem;
+  }
+
+  dropdown-component::part(customOptionContentType) {
+    margin-bottom: 0.16rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  dropdown-component::part(customOptionContentAddress) {
+    color: var(--neutral-500);
+    font-size: 0.75rem;
+    font-weight: 400;
+  }
+
+  dropdown-component::part(dropdownContent) {
+    margin-top: 0.75rem;
+  }
+
+  dropdown-component::part(dropdownTrigger) {
+    min-width: 11.5rem;
+    border-radius: 2.5rem;
+    padding: 0.375rem 0.5rem 0.375rem 0.75rem;
+    background: var(--zinc-200);
+  }
+
+  dropdown-component::part(substrateDisconnectButton) {
+    width: 100%;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    color: var(--zinc-800);
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-align: left;
+    background: rgba(0, 0, 0, 0);
+    outline: none;
+    border: none;
+    box-sizing: border-box;
+  }
+
+  dropdown-component::part(substrateDisconnectButton):hover {
+    background-color: var(--neutral-100);
+  }
+`;

--- a/packages/widget/src/components/substrate-account-selector/substrate-account-selector.ts
+++ b/packages/widget/src/components/substrate-account-selector/substrate-account-selector.ts
@@ -1,0 +1,99 @@
+import { consume } from '@lit/context';
+import type { Account } from '@polkadot-onboard/core';
+import type { HTMLTemplateResult } from 'lit';
+import { html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
+
+import { greenCircleIcon, identicon } from '../../assets';
+import { type WalletContext, walletContext } from '../../context';
+import { WalletController } from '../../controllers';
+import { shortAddress } from '../../utils';
+import { BaseComponent } from '../common/base-component';
+import type { DropdownOption } from '../common/dropdown/dropdown';
+
+import { substrateAccountSelectorStyles } from './styles';
+
+@customElement('sygma-substrate-account-selector')
+export class SubstrateAccountSelector extends BaseComponent {
+  static styles = substrateAccountSelectorStyles;
+
+  @consume({ context: walletContext, subscribe: true })
+  @state()
+  private wallets!: WalletContext;
+
+  private walletController = new WalletController(this);
+
+  private onDisconnectClicked = (): void => {
+    this.walletController.disconnectWallet();
+  };
+
+  private handleSubstrateAccountSelected = (
+    option: DropdownOption<Account>
+  ): void => this.walletController.onSubstrateAccountSelected(option.value);
+
+  private renderDisconnectSubstrateButton(): HTMLTemplateResult | undefined {
+    return html` <div
+      class="dropdownOption substrateDisconnectButton"
+      part="substrateDisconnectButton"
+      @click=${this.onDisconnectClicked}
+    >
+      Disconnect
+    </div>`;
+  }
+
+  private normalizeOptionsData(): DropdownOption<Account>[] {
+    const substrateWallet = this.wallets.substrateWallet;
+    if (!substrateWallet) return [];
+
+    return substrateWallet.accounts.map((account: Account) => ({
+      id: account.address,
+      name: shortAddress(account?.address ?? ''),
+      value: account,
+      icon: greenCircleIcon,
+      customOptionHtml: this.renderCustomOptionContent(account)
+    }));
+  }
+
+  private renderCustomOptionContent({
+    name,
+    address
+  }: Account): HTMLTemplateResult {
+    return html`
+      <div part="customOptionContent">
+        <div part="customOptionContentHeader">
+          <span part="customOptionContentName">${name}</span>
+        </div>
+        <div part="customOptionContentMain">
+          ${identicon}
+          <div part="customOptionContentAccountData">
+            <span part="customOptionContentAddress">${address}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  render(): HTMLTemplateResult {
+    const substrateWallet = this.wallets.substrateWallet;
+    const substrateAccount = substrateWallet?.accounts[0];
+    const options = this.normalizeOptionsData();
+
+    return when(
+      !!substrateAccount,
+      () =>
+        html`<dropdown-component
+          .actionOption=${this.renderDisconnectSubstrateButton()}
+          .options=${options}
+          .onOptionSelected=${this.handleSubstrateAccountSelected}
+        >
+        </dropdown-component>`
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'sygma-substrate-account-selector': SubstrateAccountSelector;
+  }
+}

--- a/packages/widget/src/components/transfer/fungible/fungible-token-transfer.ts
+++ b/packages/widget/src/components/transfer/fungible/fungible-token-transfer.ts
@@ -13,7 +13,7 @@ import '../../address-input';
 import '../../amount-selector';
 import './transfer-button';
 import './transfer-status';
-import { BaseComponent } from '../../common/base-component/base-component';
+import { BaseComponent } from '../../common/base-component';
 import '../../network-selector';
 import { Directions } from '../../network-selector/network-selector';
 import { WalletController } from '../../../controllers';

--- a/packages/widget/src/components/transfer/fungible/fungible-token-transfer.ts
+++ b/packages/widget/src/components/transfer/fungible/fungible-token-transfer.ts
@@ -9,6 +9,7 @@ import {
   FungibleTokenTransferController,
   FungibleTransferState
 } from '../../../controllers/transfers/fungible-token-transfer';
+import '../../common/buttons/button';
 import '../../address-input';
 import '../../amount-selector';
 import './transfer-button';
@@ -144,6 +145,7 @@ export class FungibleTokenTransfer extends BaseComponent {
         <sygma-address-input
           .address=${this.transferController.destinatonAddress}
           .onAddressChange=${this.transferController.onDestinationAddressChange}
+          .networkType=${this.transferController.destinationNetwork?.type}
         >
         </sygma-address-input>
       </section>

--- a/packages/widget/src/components/transfer/fungible/styles.ts
+++ b/packages/widget/src/components/transfer/fungible/styles.ts
@@ -5,11 +5,12 @@ export const styles = css`
     display: flex;
     justify-content: center;
   }
+
   form {
     width: 100%;
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.25rem;
+    gap: 0.5rem;
   }
 `;

--- a/packages/widget/src/components/transfer/fungible/transfer-button/transfer-button.ts
+++ b/packages/widget/src/components/transfer/fungible/transfer-button/transfer-button.ts
@@ -4,7 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 import { FungibleTransferState } from '../../../../controllers/transfers/fungible-token-transfer';
 import type { Button } from '../../../common';
-import { BaseComponent } from '../../../common';
+import { BaseComponent } from '../../../common/base-component';
 
 const enabledStates = [
   FungibleTransferState.WRONG_CHAIN,

--- a/packages/widget/src/components/transfer/fungible/transfer-status/styles.ts
+++ b/packages/widget/src/components/transfer/fungible/transfer-status/styles.ts
@@ -16,7 +16,7 @@ export const styles = css`
     flex-direction: column;
     align-items: center;
     border-radius: 1.5rem;
-    border: 1px solid var(--zinc-200);
+    border: 0.0625rem solid var(--zinc-200);
   }
 
   .destinationMessage {

--- a/packages/widget/src/components/transfer/fungible/transfer-status/transfer-status.ts
+++ b/packages/widget/src/components/transfer/fungible/transfer-status/transfer-status.ts
@@ -1,9 +1,9 @@
 import { BigNumber, utils } from 'ethers';
 import { html, type HTMLTemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { BaseComponent } from '../../../common';
-import { greenMark, networkIconsMap } from '../../../../assets';
 import { DEFAULT_ETH_DECIMALS } from '../../../../constants';
+import { greenMark, networkIconsMap } from '../../../../assets';
+import { BaseComponent } from '../../../common/base-component';
 import { styles } from './styles';
 
 @customElement('sygma-transfer-status')

--- a/packages/widget/src/context/wallet.ts
+++ b/packages/widget/src/context/wallet.ts
@@ -5,7 +5,7 @@ import type { EIP1193Provider } from '@web3-onboard/core';
 import type { HTMLTemplateResult } from 'lit';
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { BaseComponent } from '../components/common/base-component/base-component';
+import { BaseComponent } from '../components/common/base-component';
 
 export interface EvmWallet {
   address: string;
@@ -15,6 +15,7 @@ export interface EvmWallet {
 
 export interface SubstrateWallet {
   signer: Signer;
+  signerAddress: string;
   accounts: Account[];
   unsubscribeSubstrateAccounts?: UnsubscribeFn;
   disconnect?: () => Promise<void>;
@@ -23,6 +24,11 @@ export interface SubstrateWallet {
 export interface WalletContext {
   evmWallet?: EvmWallet;
   substrateWallet?: SubstrateWallet;
+}
+
+export enum WalletContextKeys {
+  EVM_WALLET = 'evmWallet',
+  SUBSTRATE_WALLET = 'substrateWallet'
 }
 
 declare global {

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -137,8 +137,14 @@ export class FungibleTokenTransferController implements ReactiveController {
   };
 
   onDestinationNetworkSelected = (network: Domain | undefined): void => {
+    if (this.destinationNetwork?.type !== network?.type) {
+      this.destinatonAddress = '';
+    }
+
     this.destinationNetwork = network;
-    if (this.sourceNetwork && !this.selectedResource) {
+    this.selectedResource = undefined;
+
+    if (this.sourceNetwork) {
       //filter resources
       void this.filterDestinationNetworksAndResources(this.sourceNetwork);
       return;

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -13,6 +13,7 @@ import type { ReactiveController, ReactiveElement } from 'lit';
 import { MAINNET_EXPLORER_URL, TESTNET_EXPLORER_URL } from '../../constants';
 import { walletContext } from '../../context';
 
+import { SdkInitializedEvent } from '../../interfaces';
 import { buildEvmFungibleTransactions, executeNextEvmTransaction } from './evm';
 
 export enum FungibleTransferState {
@@ -82,10 +83,30 @@ export class FungibleTokenTransferController implements ReactiveController {
     this.reset();
   }
 
+  /**
+   * Infinite Try/catch wrapper around
+   * {@link Config} from `@buildwithsygma/sygma-sdk-core`
+   * and emits a {@link SdkInitializedEvent}
+   * @param {number} time to wait before retrying request in ms
+   * @returns {void}
+   */
+  async retryInitSdk(retryMs = 100): Promise<void> {
+    try {
+      await this.config.init(1, this.env);
+      this.host.dispatchEvent(
+        new SdkInitializedEvent({ hasInitialized: true })
+      );
+    } catch (error) {
+      setTimeout(() => {
+        this.retryInitSdk(retryMs * 2).catch(console.error);
+      }, retryMs);
+    }
+  }
+
   async init(env: Environment): Promise<void> {
     this.host.requestUpdate();
     this.env = env;
-    await this.config.init(1, env);
+    await this.retryInitSdk();
     this.supportedSourceNetworks = this.config.getDomains();
     //remove once we have proper substrate transfer support
     // .filter((n) => n.type === Network.EVM);

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -9,8 +9,10 @@ import { ContextConsumer } from '@lit/context';
 import type { UnsignedTransaction } from 'ethers';
 import { BigNumber } from 'ethers';
 import type { ReactiveController, ReactiveElement } from 'lit';
-import { walletContext } from '../../context/wallet';
+
 import { MAINNET_EXPLORER_URL, TESTNET_EXPLORER_URL } from '../../constants';
+import { walletContext } from '../../context';
+
 import { buildEvmFungibleTransactions, executeNextEvmTransaction } from './evm';
 
 export enum FungibleTransferState {
@@ -84,10 +86,9 @@ export class FungibleTokenTransferController implements ReactiveController {
     this.host.requestUpdate();
     this.env = env;
     await this.config.init(1, env);
-    this.supportedSourceNetworks = this.config
-      .getDomains()
-      //remove once we have proper substrate transfer support
-      .filter((n) => n.type === Network.EVM);
+    this.supportedSourceNetworks = this.config.getDomains();
+    //remove once we have proper substrate transfer support
+    // .filter((n) => n.type === Network.EVM);
     this.supportedDestinationNetworks = this.config.getDomains();
     this.host.requestUpdate();
   }

--- a/packages/widget/src/controllers/wallet-manager/manager.ts
+++ b/packages/widget/src/controllers/wallet-manager/manager.ts
@@ -163,6 +163,7 @@ export class WalletController implements ReactiveController {
         new WalletUpdateEvent({
           substrateWallet: {
             signer: wallet.signer,
+            signerAddress: accounts[0].address,
             accounts,
             unsubscribeSubstrateAccounts: unsub,
             disconnect: wallet.disconnect
@@ -199,6 +200,8 @@ export class WalletController implements ReactiveController {
         new WalletUpdateEvent({
           substrateWallet: {
             signer: this.walletContext.value.substrateWallet.signer,
+            signerAddress:
+              this.walletContext.value.substrateWallet.signerAddress,
             disconnect: this.walletContext.value.substrateWallet.disconnect,
             unsubscribeSubstrateAccounts:
               this.walletContext.value.substrateWallet
@@ -211,6 +214,20 @@ export class WalletController implements ReactiveController {
     }
     if (accounts.length === 0) {
       this.disconnectSubstrateWallet();
+    }
+  };
+
+  onSubstrateAccountSelected = (account: Account): void => {
+    if (this.walletContext.value?.substrateWallet) {
+      this.host.dispatchEvent(
+        new WalletUpdateEvent({
+          substrateWallet: {
+            signer: this.walletContext.value.substrateWallet.signer,
+            signerAddress: account.address,
+            accounts: this.walletContext.value.substrateWallet.accounts
+          }
+        })
+      );
     }
   };
 }

--- a/packages/widget/src/interfaces/index.ts
+++ b/packages/widget/src/interfaces/index.ts
@@ -34,3 +34,11 @@ export interface ISygmaProtocolWidget {
   customLogo?: SVGElement;
   theme?: Theme;
 }
+
+export class SdkInitializedEvent extends CustomEvent<{
+  hasInitialized: boolean;
+}> {
+  constructor(update: { hasInitialized: boolean }) {
+    super('sdk-initialized', { detail: update, composed: true, bubbles: true });
+  }
+}

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -7,10 +7,12 @@ export const styles = css`
     --zinc-400: #a1a1aa;
     --zinc-500: #71717a;
     --zinc-700: #3f3f46;
+    --zinc-800: #27272a;
     --zinc-900: #18181b;
     --white: #fff;
     --gray-100: #f3f4f6;
     --neutral-100: #f5f5f5;
+    --neutral-500: #334155;
     --neutral-600: #525252;
     --primary-300: #a5b4fc;
     --primary-500: #6366f1;
@@ -49,7 +51,7 @@ export const styles = css`
   }
 
   .networkSelectionWrapper {
-    margin: 1rem 0 0.5rem 0;
+    margin: 1rem 0;
   }
 
   .widgetHeader {

--- a/packages/widget/src/widget.ts
+++ b/packages/widget/src/widget.ts
@@ -21,6 +21,7 @@ import './context/wallet';
 import type {
   Eip1193Provider,
   ISygmaProtocolWidget,
+  SdkInitializedEvent,
   Theme
 } from './interfaces';
 import { styles } from './styles';
@@ -60,6 +61,9 @@ class SygmaProtocolWidget
   private isLoading = false;
 
   @state()
+  private sdkInitialized = false;
+
+  @state()
   private sourceNetwork?: Domain;
 
   private renderConnect(): HTMLTemplateResult {
@@ -85,6 +89,8 @@ class SygmaProtocolWidget
           </section>
           <section class="widgetContent">
             <sygma-fungible-transfer
+              @sdk-initialized=${(event: SdkInitializedEvent) =>
+                (this.sdkInitialized = event.detail.hasInitialized)}
               .onSourceNetworkSelected=${(domain: Domain) =>
                 (this.sourceNetwork = domain)}
               .whitelistedSourceResources=${this.whitelistedSourceNetworks}
@@ -94,7 +100,7 @@ class SygmaProtocolWidget
           </section>
           <section class="poweredBy">${sygmaLogo} Powered by Sygma</section>
           ${when(
-            this.isLoading,
+            this.isLoading || !this.sdkInitialized,
             () => html`<sygma-overlay-component></sygma-overlay-component>`
           )}
         </section>

--- a/packages/widget/src/widget.ts
+++ b/packages/widget/src/widget.ts
@@ -14,7 +14,7 @@ import { sygmaLogo } from './assets';
 import './components';
 import './components/address-input';
 import './components/amount-selector';
-import { BaseComponent } from './components/common/base-component/base-component';
+import { BaseComponent } from './components/common/base-component';
 import './components/transfer/fungible/fungible-token-transfer';
 import './components/network-selector';
 import './context/wallet';

--- a/packages/widget/tests/unit/components/address-input/address-input.test.ts
+++ b/packages/widget/tests/unit/components/address-input/address-input.test.ts
@@ -64,7 +64,7 @@ describe('address-input component', function () {
 
     el = await fixture(html`
       <sygma-address-input
-        .network=${Network.SUBSTRATE}
+        .networkType=${Network.SUBSTRATE}
         .address=${'42sy'}
         .onAddressChange=${mockAddressChangeHandler}
       ></sygma-address-input>
@@ -162,7 +162,7 @@ describe('address-input component', function () {
 
     const el = await fixture(html`
       <sygma-address-input
-        .network=${Network.SUBSTRATE}
+        .networkType=${Network.SUBSTRATE}
         .onAddressChange=${mockAddressChangeHandler}
       ></sygma-address-input>
     `);
@@ -219,7 +219,7 @@ describe('address-input component', function () {
 
     const el = await fixture(html`
       <sygma-address-input
-        .network=${Network.SUBSTRATE}
+        .networkType=${Network.SUBSTRATE}
         .onAddressChange=${mockAddressChangeHandler}
       ></sygma-address-input>
     `);

--- a/packages/widget/tests/unit/components/buttons/connect-wallet.test.ts
+++ b/packages/widget/tests/unit/components/buttons/connect-wallet.test.ts
@@ -92,51 +92,6 @@ describe('connect-wallet button', function () {
     assert.equal(disconnectButton.textContent?.trim(), 'Disconnect');
   });
 
-  it('displays connected substrate wallet', async () => {
-    const walletContext = await fixture<WalletContextProvider>(html`
-      <sygma-wallet-context-provider></sygma-wallet-context-provider>
-    `);
-    walletContext.dispatchEvent(
-      new WalletUpdateEvent({
-        substrateWallet: {
-          accounts: [
-            {
-              address: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe'
-            }
-          ],
-          signer: {}
-        }
-      })
-    );
-    const connectComponent = await fixture<ConnectWalletButton>(
-      html` <sygma-connect-wallet-btn></sygma-connect-wallet-btn> `,
-      { parentNode: walletContext }
-    );
-
-    const walletAddressEl =
-      connectComponent.shadowRoot!.querySelector<HTMLSpanElement>(
-        '.walletAddress'
-      );
-
-    assert.isDefined(
-      walletAddressEl,
-      'Connected wallet address is not displayed'
-    );
-
-    assert.equal(
-      walletAddressEl?.title,
-      '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe'
-    );
-    assert.equal(walletAddressEl?.textContent?.trim(), '155Eek...Xzjqe');
-
-    const disconnectButton = connectComponent.shadowRoot!.querySelector(
-      '.connectWalletButton'
-    ) as HTMLButtonElement;
-
-    assert.isDefined(disconnectButton, 'Button missing');
-    assert.equal(disconnectButton.textContent?.trim(), 'Disconnect');
-  });
-
   it('updates connected evm wallet', async () => {
     const walletContext = await fixture<WalletContextProvider>(html`
       <sygma-wallet-context-provider></sygma-wallet-context-provider>
@@ -237,6 +192,7 @@ describe('connect-wallet button', function () {
               address: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe'
             }
           ],
+          signerAddress: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe',
           signer: {}
         }
       })
@@ -314,6 +270,7 @@ describe('connect-wallet button', function () {
               address: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe'
             }
           ],
+          signerAddress: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe',
           signer: {},
           disconnect: disconnectFn
         }

--- a/packages/widget/tests/unit/components/network-selector/network-selector.test.ts
+++ b/packages/widget/tests/unit/components/network-selector/network-selector.test.ts
@@ -1,10 +1,11 @@
-import { fixture, fixtureCleanup, nextFrame } from '@open-wc/testing-helpers';
 import { Network } from '@buildwithsygma/sygma-sdk-core';
 import type { Domain } from '@buildwithsygma/sygma-sdk-core';
-import { afterEach, assert, describe, expect, it, vi } from 'vitest';
+import { fixture, fixtureCleanup, nextFrame } from '@open-wc/testing-helpers';
 import { html } from 'lit';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
+
 import { NetworkSelector } from '../../../../src/components';
-import type { Dropdown } from '../../../../src/components/common/dropdown/dropdown';
+import type { Dropdown } from '../../../../src/components/common';
 
 describe('network-selector component', function () {
   afterEach(() => {
@@ -28,7 +29,9 @@ describe('network-selector component', function () {
     const dropdown = el.shadowRoot?.querySelector(
       'dropdown-component'
     ) as Dropdown;
-    expect(dropdown?.options.length).toBe(testNetworks.length);
+
+    const dropdownOptions = dropdown.options;
+    expect(dropdownOptions?.length).toBe(testNetworks.length);
   });
 
   it('calls "onNetworkSelected" with the correct Domain object when an option is selected', async () => {

--- a/packages/widget/tests/unit/components/substrate-account-selector/substrate-account-selector.test.ts
+++ b/packages/widget/tests/unit/components/substrate-account-selector/substrate-account-selector.test.ts
@@ -1,0 +1,57 @@
+import { fixture, fixtureCleanup } from '@open-wc/testing-helpers';
+import { afterEach, assert, describe, it } from 'vitest';
+
+import { html } from 'lit';
+import type { ConnectWalletButton } from '../../../../src/components';
+import { SubstrateAccountSelector } from '../../../../src/components';
+import type { WalletContextProvider } from '../../../../src/context';
+import { WalletUpdateEvent } from '../../../../src/context';
+import type { Dropdown } from '../../../../src/components/common';
+
+describe('Substrate account selector component', function () {
+  afterEach(() => {
+    fixtureCleanup();
+  });
+
+  it('is defined', () => {
+    const el = document.createElement('sygma-substrate-account-selector');
+    assert.instanceOf(el, SubstrateAccountSelector);
+  });
+
+  it('displays connected substrate wallet', async () => {
+    const walletContext = await fixture<WalletContextProvider>(html`
+      <sygma-wallet-context-provider></sygma-wallet-context-provider>
+    `);
+    walletContext.dispatchEvent(
+      new WalletUpdateEvent({
+        substrateWallet: {
+          accounts: [
+            {
+              address: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe'
+            }
+          ],
+          signerAddress: '155EekKo19tWKAPonRFywNVsVduDegYChrDVsLE8HKhXzjqe',
+          signer: {}
+        }
+      })
+    );
+    const connectComponent = await fixture<ConnectWalletButton>(
+      html`
+        <sygma-substrate-account-selector></sygma-substrate-account-selector>
+      `,
+      { parentNode: walletContext }
+    );
+
+    const dropdown = connectComponent.shadowRoot!.querySelector<Dropdown>(
+      'dropdown-component'
+    ) as Dropdown;
+
+    assert.equal(dropdown.selectedOption!.name, '155Eek...Xzjqe');
+
+    const disconnectButton = dropdown.shadowRoot!.querySelector(
+      '.substrateDisconnectButton'
+    ) as HTMLButtonElement;
+
+    assert.equal(disconnectButton.textContent!.trim(), 'Disconnect');
+  });
+});


### PR DESCRIPTION
- Added network type to address input component
- remove selected resource on destination network change

<!--- Provide a general summary of your changes in the Title above -->

## Description

Resource selection is not updated on UI when a destination network is changed.

## Related Issue Or Context

https://github.com/sygmaprotocol/sygma-widget/issues/117

When destination network is changed by the user IMO the resource selected, amount and destination address need to be reset so that they may update the UI with correct values. I have added functionality that resets the selected resource, which compels user to select the desired token again. Furthermore, the address input should be cleared if the source network is of type `EVM` however, potential destination is of a different type

Closes: #117 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)