### PR TITLE
fix: Switching to a different TOKEN mapping for "From - TO" relationship is not updated in UI if amount is inserted

### DIFF
--- a/packages/widget/src/components/transfer/fungible/fungible-token-transfer.ts
+++ b/packages/widget/src/components/transfer/fungible/fungible-token-transfer.ts
@@ -9,6 +9,7 @@ import {
   FungibleTokenTransferController,
   FungibleTransferState
 } from '../../../controllers/transfers/fungible-token-transfer';
+import '../../common/buttons/button';
 import '../../address-input';
 import '../../resource-amount-selector';
 import './transfer-button';

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -143,10 +143,15 @@ export class FungibleTokenTransferController implements ReactiveController {
         : '';
   };
 
+  resetSelectedResource = (): void => {
+    this.selectedResource = undefined;
+  };
+
   onDestinationNetworkSelected = (network: Domain | undefined): void => {
     this.destinationNetwork = network;
     this.setSenderDefaultDestinationAddress();
-    if (this.sourceNetwork && !this.selectedResource) {
+    if (this.sourceNetwork) {
+      this.resetSelectedResource();
       //filter resources
       void this.filterDestinationNetworksAndResources(this.sourceNetwork);
       return;

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -146,7 +146,7 @@ export class FungibleTokenTransferController implements ReactiveController {
   onDestinationNetworkSelected = (network: Domain | undefined): void => {
     this.destinationNetwork = network;
     this.setSenderDefaultDestinationAddress();
-    if (this.sourceNetwork && !this.selectedResource) {
+    if (this.sourceNetwork) {
       //filter resources
       void this.filterDestinationNetworksAndResources(this.sourceNetwork);
       return;
@@ -255,40 +255,17 @@ export class FungibleTokenTransferController implements ReactiveController {
         await getRoutes(this.env, sourceNetwork.chainId, 'fungible')
       );
     }
-
     this.supportedResources = [];
-    const routes = this.routesCache.get(sourceNetwork.chainId)!;
-
-    // unselect destination if equal to source network or isn't in list of available destination networks
-    if (this.destinationNetwork?.id === sourceNetwork.id || !routes.length) {
-      this.destinationNetwork = undefined;
-      this.selectedResource = undefined;
-      this.supportedDestinationNetworks = [];
-    }
-
-    // either first time or we had source === destination
     if (!this.destinationNetwork) {
-      this.supportedDestinationNetworks = routes
-        .filter((route) => route.toDomain.chainId !== sourceNetwork.chainId)
+      this.supportedDestinationNetworks = this.routesCache
+        .get(sourceNetwork.chainId)!
+        .filter(
+          (route) =>
+            route.toDomain.chainId !== sourceNetwork.chainId &&
+            !this.supportedDestinationNetworks.includes(route.toDomain)
+        )
         .map((route) => route.toDomain);
-    } // source change but not destination, check if route is supported
-    else if (this.supportedDestinationNetworks.length && routes.length) {
-      const isSourceOnSuportedDestinations =
-        this.supportedDestinationNetworks.some(
-          (destinationDomain) =>
-            destinationDomain.chainId === this.sourceNetwork?.chainId
-        );
-      if (isSourceOnSuportedDestinations) {
-        this.supportedDestinationNetworks = routes
-          .filter(
-            (route) =>
-              route.toDomain.chainId !== sourceNetwork.chainId &&
-              !this.supportedDestinationNetworks.includes(route.toDomain)
-          )
-          .map((route) => route.toDomain);
-      }
     }
-
     this.supportedResources = this.routesCache
       .get(sourceNetwork.chainId)!
       .filter(
@@ -298,7 +275,13 @@ export class FungibleTokenTransferController implements ReactiveController {
             !this.supportedResources.includes(route.resource))
       )
       .map((route) => route.resource);
-
+    //unselect destination if equal to source network or isn't in list of available destination networks
+    if (
+      this.destinationNetwork?.id === sourceNetwork.id ||
+      !this.supportedDestinationNetworks.includes(this.destinationNetwork!)
+    ) {
+      this.destinationNetwork = undefined;
+    }
     void this.buildTransactions();
     this.host.requestUpdate();
   };

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -143,15 +143,10 @@ export class FungibleTokenTransferController implements ReactiveController {
         : '';
   };
 
-  resetSelectedResource = (): void => {
-    this.selectedResource = undefined;
-  };
-
   onDestinationNetworkSelected = (network: Domain | undefined): void => {
     this.destinationNetwork = network;
     this.setSenderDefaultDestinationAddress();
-    if (this.sourceNetwork) {
-      this.resetSelectedResource();
+    if (this.sourceNetwork && !this.selectedResource) {
       //filter resources
       void this.filterDestinationNetworksAndResources(this.sourceNetwork);
       return;


### PR DESCRIPTION
- Added network type to address input component
- remove selected resource on destination network change

<!--- Provide a general summary of your changes in the Title above -->

## Description

Resource selection is not updated on UI when a destination network is changed.

## Related Issue Or Context

https://github.com/sygmaprotocol/sygma-widget/issues/117

When destination network is changed by the user IMO the resource selected, amount and destination address need to be reset so that they may update the UI with correct values. I have added functionality that resets the selected resource, which compels user to select the desired token again. Furthermore, the address input should be cleared if the source network is of type `EVM` however, potential destination is of a different type

Closes: #117 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)