### PR TITLE
fix: Substrate balance does not update when sending tokens from RHALA 

### DIFF
--- a/packages/widget/src/controllers/wallet-manager/token-balance.ts
+++ b/packages/widget/src/controllers/wallet-manager/token-balance.ts
@@ -13,11 +13,11 @@ import { ethers, BigNumber } from 'ethers';
 import type { ReactiveController, ReactiveElement } from 'lit';
 import type { ParachainID } from '@buildwithsygma/sygma-sdk-core/substrate';
 import { getAssetBalance } from '@buildwithsygma/sygma-sdk-core/substrate';
+import Keyring from '@polkadot/keyring';
 import { walletContext } from '../../context';
 import { isEvmResource } from '../../utils';
 import { substrateProviderContext } from '../../context/wallet';
 import type { SubstrateWallet } from '../../context/wallet';
-import Keyring from '@polkadot/keyring';
 
 const BALANCE_REFRESH_MS = 5_000;
 

--- a/packages/widget/src/controllers/wallet-manager/token-balance.ts
+++ b/packages/widget/src/controllers/wallet-manager/token-balance.ts
@@ -17,6 +17,7 @@ import { walletContext } from '../../context';
 import { isEvmResource } from '../../utils';
 import { substrateProviderContext } from '../../context/wallet';
 import type { SubstrateWallet } from '../../context/wallet';
+import Keyring from '@polkadot/keyring';
 
 const BALANCE_REFRESH_MS = 5_000;
 
@@ -165,6 +166,8 @@ export class TokenBalanceController implements ReactiveController {
       return;
     }
 
+    const prefix = substrateProvider.consts.ss58Prefix as unknown as number;
+
     void async function (this: TokenBalanceController) {
       try {
         this.loadingBalance = true;
@@ -172,7 +175,7 @@ export class TokenBalanceController implements ReactiveController {
         const tokenBalance = await getAssetBalance(
           substrateProvider,
           resource.assetID as number,
-          signerAddress
+          new Keyring().encodeAddress(signerAddress, prefix)
         );
         this.loadingBalance = false;
         this.balance = BigNumber.from(tokenBalance.balance.toString());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# **This does not happen consistently so I'm marking this as a draft. If a bug is reported in future maybe we re-open and merge**

## Description

Balance always stays 0, Happening when using talisman wallet

## Related Issue Or Context

This is happening due to the fact that code doesn't query the correct address format balance

Closes: #?
