### PR TITLE
fix: Gas Fee estimation behavior, is not consistent for the actual transfer TX

### DIFF
--- a/packages/widget/src/controllers/transfers/evm/execute.ts
+++ b/packages/widget/src/controllers/transfers/evm/execute.ts
@@ -28,7 +28,6 @@ export async function executeNextEvmTransaction(
       this.host.requestUpdate();
       await tx.wait();
       this.pendingEvmApprovalTransactions.shift();
-      await this.estimateGas();
     } catch (e) {
       console.log(e);
       this.errorMessage = 'Approval transaction reverted or rejected';
@@ -36,6 +35,7 @@ export async function executeNextEvmTransaction(
       this.waitingUserConfirmation = false;
       this.waitingTxExecution = false;
       this.host.requestUpdate();
+      this.estimateGas();
     }
     return;
   }

--- a/packages/widget/src/controllers/transfers/evm/execute.ts
+++ b/packages/widget/src/controllers/transfers/evm/execute.ts
@@ -35,7 +35,7 @@ export async function executeNextEvmTransaction(
       this.waitingUserConfirmation = false;
       this.waitingTxExecution = false;
       this.host.requestUpdate();
-      this.estimateGas();
+      await this.estimateGas();
     }
     return;
   }

--- a/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
+++ b/packages/widget/src/controllers/transfers/fungible-token-transfer.ts
@@ -557,7 +557,7 @@ export class FungibleTokenTransferController implements ReactiveController {
 
     switch (state) {
       case FungibleTransferState.PENDING_APPROVALS:
-        transactions.push(...this.pendingEvmApprovalTransactions);
+        transactions.push(this.pendingEvmApprovalTransactions[0]);
         break;
       case FungibleTransferState.PENDING_TRANSFER:
         transactions.push(this.pendingTransferTransaction);


### PR DESCRIPTION
## Description

Gas estimation for transfer transaction was not calculated as the estimate gas function was called when the transfer state returned from `getTransferState` was the one which had no case handled in `estimateEvmGas`

## Related Issue Or Context

#190 

Closes: #190 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)