### PR TITLE
fix: New URL by clicking the button

### DIFF
--- a/examples/react-widget-app/src/App.tsx
+++ b/examples/react-widget-app/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
 
   const obtainTokensClick = () => {
     window.open(
-      'https://docs.buildwithsygma.com/environments/testnet/obtain-testnet-tokens',
+      'https://docs.buildwithsygma.com/resources/environments/testnet/obtain-testnet-tokens',
       '_blank',
     );
   };


### PR DESCRIPTION
Changed URL when clicking the button `Obtain testnet tokens`. 

closes #207 