### PR TITLE
chore: update react README

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,6 +10,7 @@ You will need to add this dependency to your project first:
 
 ```bash
 yarn add @polkadot/extension-inject
+yarn add @polkadot/types
 ```
 
 ### Installing the Widget
@@ -29,9 +30,11 @@ import { SygmaProtocolReactWidget } from '@buildwithsygma/sygmaprotocol-react-wi
 
 function MyDapp(){
   return (
-    <SygmaProtocolReactWidget />;
-  )
+    <SygmaProtocolReactWidget />
+  );
 }
+
+export default MyDapp;
 ```
 
 You can also pass props to the Widget component to customize it:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,7 +10,7 @@ You will need to add this dependency to your project first:
 
 ```bash
 yarn add @polkadot/extension-inject
-yarn add @polkadot/types
+yarn add -D @polkadot/types
 ```
 
 ### Installing the Widget


### PR DESCRIPTION
tiny documentation update: 

- fix minor quaggle with a misplaced `;`
- add polkadot/types dependency 
- add export statement for devEx